### PR TITLE
Adds a fix for using initial temperature in Transient Thermal Analysis

### DIFF
--- a/geometry-mechanical-dpf/wf_gmd_02_mechanical.py
+++ b/geometry-mechanical-dpf/wf_gmd_02_mechanical.py
@@ -193,7 +193,7 @@ temperature_result = steady_solution.AddTemperature()
 steady_solution.Solve(True)
 
 # Transient analysis setup
-initial_condition = steady_solution.Children[0]
+initial_condition = transient.InitialConditions[0]
 initial_condition.InitialTemperature = InitialTemperatureType.NonUniform
 initial_condition.InitialEnvironment = steady
 


### PR DESCRIPTION
Fix in example: geometry-mechanical-dpf
- The previous was self-referencing the initial temperature to steady state thermal analysis itself. 

- The issue is also there in PyMechanical as it does not throw any error even through the object does not even exists.

This commit fixes the code to set initial temperature and issue https://github.com/ansys/pyansys-workflows/issues/39.