### PR TITLE
build: fix ansys-tools-visualization-interface on geometry-mesh for 25r1

### DIFF
--- a/geometry-mesh/requirements_25.1.txt
+++ b/geometry-mesh/requirements_25.1.txt
@@ -1,3 +1,4 @@
 ansys-geometry-core[all]==0.9.2
 ansys-meshing-prime==0.7.0
 numpy<2.3
+ansys-tools-visualization-interface<0.10


### PR DESCRIPTION
New ansys-tools-visualization-interface release is breaking the builds, limiting