### PR TITLE
ci: add notify on failure

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -168,3 +168,34 @@ jobs:
           github_token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           cname: ${{ env.DOCUMENTATION_CNAME }}
           force_orphan: true
+
+  notify:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    needs: [geometry-mesh, geometry-mesh-fluent, fluent-mechanical, mapdl-dpf, speos-optislang, maxwell2d-lumerical, q3d-lumerical, compile-docs, publish-docs]
+    if: ${{ github.event_name == 'schedule' && failure() }}
+    steps:
+      - name: Microsoft Teams Notification
+        uses: skitionek/notify-microsoft-teams@216b8b28967e7e89b0b64b81dc94aeae90e642ab # v1.3.0
+        with:
+          webhook_url: ${{ secrets.MSTEAMS_WEBHOOK }}
+          raw: >-
+            {
+              "@type": "MessageCard",
+              "@context": "http://schema.org/extensions",
+              "summary": "Documentation build failed",
+              "themeColor": "f44336",
+              "title": "PyAnsys workflows documentation build failed",
+              "sections": [
+                {
+                  "activityTitle": "PyAnsys workflows documentation build failed",
+                  "activitySubtitle": "Check the run for more details: https://github.com/ansys/pyansys-workflows/actions/runs/${{ github.run_id }}",
+                  "facts": [
+                    {
+                      "name": "Status",
+                      "value": "Failed"
+                    }
+                  ]
+                }
+              ]
+            }


### PR DESCRIPTION
As title says - scheduled runs will report failures on team channel